### PR TITLE
修复 OutlookEmail 读取过期验证码

### DIFF
--- a/backend/mailbox/outlook_pool.py
+++ b/backend/mailbox/outlook_pool.py
@@ -9,6 +9,8 @@ import random
 import re
 import threading
 import time
+from datetime import datetime
+from email.utils import parsedate_to_datetime
 from http.cookies import SimpleCookie
 from typing import Any, Callable, Iterable, List, Optional
 from urllib.parse import urlsplit
@@ -658,6 +660,50 @@ def get_temp_messages(
     return pick_list(data)
 
 
+def message_received_at(message: Any) -> Optional[float]:
+    """Return an email's received time as a Unix timestamp when available."""
+    if not isinstance(message, dict):
+        return None
+
+    for key in (
+        "timestamp",
+        "received_at",
+        "receivedAt",
+        "receivedDateTime",
+        "date",
+        "created_at",
+        "createdAt",
+    ):
+        raw_value = message.get(key)
+        if raw_value is None or isinstance(raw_value, bool):
+            continue
+
+        if isinstance(raw_value, (int, float)):
+            timestamp = float(raw_value)
+        else:
+            value = str(raw_value or "").strip()
+            if not value:
+                continue
+            try:
+                timestamp = float(value)
+            except ValueError:
+                try:
+                    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+                except ValueError:
+                    try:
+                        parsed = parsedate_to_datetime(value)
+                    except (TypeError, ValueError, OverflowError):
+                        continue
+                timestamp = parsed.timestamp()
+
+        # Some temp-mail APIs expose Unix milliseconds instead of seconds.
+        if timestamp > 100_000_000_000:
+            timestamp /= 1000
+        if timestamp > 0:
+            return timestamp
+    return None
+
+
 def mail_text(message: Any) -> str:
     if not isinstance(message, dict):
         return ""
@@ -713,6 +759,7 @@ def wait_for_code(
     sleep_with_cancel: Callable[[float, Optional[Callable[[], bool]]], None],
     log_callback: Optional[Callable[[str], None]] = None,
     cancel_callback: Optional[Callable[[], bool]] = None,
+    min_received_at: Optional[float] = None,
 ) -> str:
     deadline = time.time() + timeout
     seen_ids: set[str] = set()
@@ -758,6 +805,19 @@ def wait_for_code(
             if message_id in seen_ids:
                 continue
             seen_ids.add(message_id)
+            if min_received_at is not None:
+                received_at = message_received_at(message)
+                if received_at is None:
+                    if log_callback:
+                        log_callback("[Debug] OutlookEmail 跳过无可用收件时间的邮件")
+                    continue
+                if received_at <= min_received_at:
+                    if log_callback:
+                        log_callback(
+                            "[Debug] OutlookEmail 跳过提交邮箱前收到的邮件: "
+                            f"received_at={received_at:.3f} <= submitted_at={min_received_at:.3f}"
+                        )
+                    continue
             if log_callback:
                 log_callback(f"[Debug] OutlookEmail 收到邮件: {subject} ({sender_text(message)})")
             code = extract_verification_code(text, subject)

--- a/backend/registration/engine.py
+++ b/backend/registration/engine.py
@@ -748,6 +748,7 @@ def outlookemail_get_oai_code(
     poll_interval=3,
     log_callback=None,
     cancel_callback=None,
+    min_received_at=None,
 ):
     return outlookemail_provider.wait_for_code(
         http_get,
@@ -763,6 +764,7 @@ def outlookemail_get_oai_code(
         proxies=get_proxies(),
         timeout=timeout,
         poll_interval=poll_interval,
+        min_received_at=min_received_at,
         raise_if_cancelled=raise_if_cancelled,
         sleep_with_cancel=sleep_with_cancel,
         log_callback=log_callback,
@@ -1431,6 +1433,7 @@ def get_oai_code(
     log_callback=None,
     cancel_callback=None,
     resend_callback=None,
+    min_received_at=None,
 ):
     provider = get_email_provider()
     if provider == "outlookemail":
@@ -1440,6 +1443,7 @@ def get_oai_code(
             poll_interval=poll_interval,
             log_callback=log_callback,
             cancel_callback=cancel_callback,
+            min_received_at=min_received_at,
         )
     if provider == "yyds":
         return yyds_get_oai_code(
@@ -2142,13 +2146,14 @@ def run_registration(count):
                             log_callback=lambda m: registration_log(f"[W{wid+1}] {m}"),
                             cancel_callback=controller.should_stop,
                         )
-                        email, dev_token = fill_email_and_submit(
+                        email, dev_token, submitted_at = fill_email_and_submit(
                             log_callback=lambda m: registration_log(f"[W{wid+1}] {m}"),
                             cancel_callback=controller.should_stop,
                         )
                         code = fill_code_and_submit(
                             email,
                             dev_token,
+                            submitted_at=submitted_at,
                             log_callback=lambda m: registration_log(f"[W{wid+1}] {m}"),
                             cancel_callback=controller.should_stop,
                         )
@@ -2416,7 +2421,7 @@ def run_registration(count):
                         log_callback=registration_log, cancel_callback=controller.should_stop
                     )
                     registration_log("[*] 2. 创建邮箱并提交")
-                    email, dev_token = fill_email_and_submit(
+                    email, dev_token, submitted_at = fill_email_and_submit(
                         log_callback=registration_log, cancel_callback=controller.should_stop
                     )
                     registration_log(f"[*] 邮箱: {email}")
@@ -2435,6 +2440,7 @@ def run_registration(count):
                         code = fill_code_and_submit(
                             email,
                             dev_token,
+                            submitted_at=submitted_at,
                             log_callback=registration_log,
                             cancel_callback=controller.should_stop,
                         )

--- a/backend/registration/signup_flow.py
+++ b/backend/registration/signup_flow.py
@@ -836,6 +836,7 @@ return candidates[0].text || true;
             sleep_with_cancel(0.5, cancel_callback)
             continue
         sleep_with_cancel(0.8, cancel_callback)
+        submit_clicked_at = time.time()
         clicked = _native_click_action(
             (
                 "注册", "继续", "下一步", "确认", "sign up", "signup", "continue", "next", "create account",
@@ -854,6 +855,7 @@ return candidates[0].text || true;
             ),
         )
         if not clicked:
+            submit_clicked_at = time.time()
             clicked = page.run_js(
                 r"""
 function isVisible(node) {
@@ -936,7 +938,7 @@ return 'enter';
                 if log_callback:
                     detail = f" ({clicked})" if isinstance(clicked, str) else ""
                     log_callback(f"[*] 已填写邮箱并提交: {email}{detail}")
-                return email, dev_token
+                return email, dev_token, submit_clicked_at
             if log_callback and time.time() - last_diag_time >= 5:
                 last_diag_time = time.time()
                 log_callback(f"[Debug] 已点击注册但页面未前进，重试提交: {email}")
@@ -953,7 +955,14 @@ return 'enter';
     raise Exception("未找到邮箱输入框或注册按钮")
 
 
-def fill_code_and_submit(email, dev_token, timeout=180, log_callback=None, cancel_callback=None):
+def fill_code_and_submit(
+    email,
+    dev_token,
+    timeout=180,
+    log_callback=None,
+    cancel_callback=None,
+    submitted_at=None,
+):
     def _resend_code():
         native = _native_click_action(("重新发送", "再次发送", "resend", "reenviar", "renvoyer", "erneut senden", "再送"))
         if native:
@@ -976,6 +985,7 @@ return false;
         log_callback=log_callback,
         cancel_callback=cancel_callback,
         resend_callback=_resend_code,
+        min_received_at=submitted_at,
     )
     if not code:
         raise Exception("获取验证码失败")

--- a/backend/tests/test_outlook_pool.py
+++ b/backend/tests/test_outlook_pool.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime, timezone
 
 from backend.mailbox import outlook_pool
 
@@ -255,6 +256,73 @@ class OutlookEmailDisableTests(unittest.TestCase):
             session_cookie="session=initial",
         )
         self.assertTrue(result["success"])
+
+
+class OutlookEmailCodeTimeTests(unittest.TestCase):
+    def test_message_received_at_supports_api_timestamp_formats(self):
+        self.assertEqual(
+            outlook_pool.message_received_at({"timestamp": 1_700_000_000_000}),
+            1_700_000_000,
+        )
+        self.assertEqual(
+            outlook_pool.message_received_at({"date": "2026-08-04T12:00:00Z"}),
+            datetime(2026, 8, 4, 12, tzinfo=timezone.utc).timestamp(),
+        )
+        self.assertIsNone(outlook_pool.message_received_at({"date": "unknown"}))
+
+    def test_wait_for_code_ignores_messages_before_submission(self):
+        submitted_at = 1_700_000_000.5
+        requested = []
+
+        def http_get(url, **kwargs):
+            requested.append((url, kwargs))
+            return FakeResponse(
+                {
+                    "success": True,
+                    "emails": [
+                        {
+                            "id": "old",
+                            "subject": "OLD-111 xAI",
+                            "date": submitted_at - 1,
+                            "body_preview": "OLD-111",
+                        },
+                        {
+                            "id": "boundary",
+                            "subject": "BND-333 xAI",
+                            "date": submitted_at,
+                            "body_preview": "BND-333",
+                        },
+                        {
+                            "id": "missing-time",
+                            "subject": "MIS-444 xAI",
+                            "body_preview": "MIS-444",
+                        },
+                        {
+                            "id": "new",
+                            "subject": "NEW-222 xAI",
+                            "date": submitted_at + 1,
+                            "body_preview": "NEW-222",
+                        },
+                    ],
+                }
+            )
+
+        code = outlook_pool.wait_for_code(
+            http_get,
+            lambda: None,
+            "http://mail-pool.test",
+            "fixture@outlook.com",
+            api_key="api-key",
+            source="accounts",
+            timeout=1,
+            poll_interval=0,
+            min_received_at=submitted_at,
+            raise_if_cancelled=lambda _callback: None,
+            sleep_with_cancel=lambda _seconds, _callback: None,
+        )
+
+        self.assertEqual(code, "NEW-222")
+        self.assertEqual(requested[0][1]["params"]["email"], "fixture@outlook.com")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 问题

OutlookEmail 验证码轮询会直接解析当前邮件列表，邮箱中存在历史验证码邮件时可能返回已过期验证码，导致注册验证失败。

## 修改

- 在邮箱提交动作发生时记录点击时间，并贯穿注册流程传给 OutlookEmail 验证码轮询
- 统一解析 accounts/temp 来源的秒、毫秒、ISO 及 RFC 邮件时间
- 仅接受收件时间严格晚于提交点击时间的邮件
- 跳过旧邮件、与点击时间相等的邮件和缺少有效收件时间的邮件
- 增加邮件时间解析与旧验证码过滤回归测试

## 验证

- python -m unittest backend.tests.test_outlook_pool backend.tests.test_mailbox_deactivation_flow backend.tests.test_job_tracking -v（15/15 通过）
- python -m py_compile backend/mailbox/outlook_pool.py backend/registration/signup_flow.py backend/registration/engine.py backend/tests/test_outlook_pool.py
- git diff --check