### PR TITLE
fix: strip style blocks and tighten code regex to avoid false verification codes

### DIFF
--- a/backend/mailbox/cloud_mail.py
+++ b/backend/mailbox/cloud_mail.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import re
 import threading
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from backend.mailbox.utilities import extract_verification_code, generate_username
+from backend.mailbox.utilities import extract_verification_code, generate_username, strip_html
 
 HttpGet = Callable[..., Any]
 HttpPost = Callable[..., Any]
@@ -286,10 +285,10 @@ def wait_for_code(
                         parts.append(value)
                 html_value = msg.get("html") or msg.get("htmlContent") or msg.get("html_content")
                 if isinstance(html_value, str):
-                    parts.append(re.sub(r"<[^>]+>", " ", html_value))
+                    parts.append(strip_html(html_value))
                 elif isinstance(html_value, list):
                     parts.extend(
-                        re.sub(r"<[^>]+>", " ", item)
+                        strip_html(item)
                         for item in html_value
                         if isinstance(item, str)
                     )
@@ -297,7 +296,7 @@ def wait_for_code(
                 if log_callback:
                     log_callback(f"[Debug] CloudMail 收到邮件: {subject}")
                 combined = "\n".join(parts)
-                plain_text = re.sub(r"<[^>]+>", " ", combined)
+                plain_text = strip_html(combined)
                 code = extract_verification_code(f"{combined}\n{plain_text}", subject)
                 if code:
                     if log_callback:

--- a/backend/mailbox/cloudflare_worker.py
+++ b/backend/mailbox/cloudflare_worker.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
-import re
 import secrets
 import string
 import time
 from typing import Any, Callable, Dict, List, Optional
 
-from backend.mailbox.utilities import extract_verification_code, generate_username, pick_list_payload
+from backend.mailbox.utilities import (
+    extract_verification_code,
+    generate_username,
+    pick_list_payload,
+    strip_html,
+)
 
 HttpGet = Callable[..., Any]
 HttpPost = Callable[..., Any]
@@ -366,7 +370,7 @@ def wait_for_code(
             if isinstance(html_list, str):
                 html_list = [html_list]
             for h in html_list:
-                parts.append(re.sub(r"<[^>]+>", " ", h))
+                parts.append(strip_html(h))
             subject = str(msg.get("subject", "") or "")
             combined = "\n".join(parts)
             try:
@@ -388,7 +392,7 @@ def wait_for_code(
                 if isinstance(html_list2, str):
                     html_list2 = [html_list2]
                 for h in html_list2:
-                    combined += "\n" + re.sub(r"<[^>]+>", " ", h)
+                    combined += "\n" + strip_html(h)
                 if not subject:
                     subject = str(detail.get("subject", "") or "")
             except Exception as exc:

--- a/backend/mailbox/duck_mail.py
+++ b/backend/mailbox/duck_mail.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import re
 import secrets
 import string
 from typing import Any, Callable, Dict, List, Optional
+
+from backend.mailbox.utilities import strip_html
 
 API_BASE_DEFAULT = "https://api.duckmail.sbs"
 
@@ -253,7 +254,7 @@ def wait_for_code(
                 html_list = [html_list]
             for h in html_list:
                 if isinstance(h, str):
-                    parts.append(re.sub(r"<[^>]+>", " ", h))
+                    parts.append(strip_html(h))
             combined = "\n".join(parts)
             subject = str(detail.get("subject", "") or "")
             if log_callback:

--- a/backend/mailbox/outlook_pool.py
+++ b/backend/mailbox/outlook_pool.py
@@ -15,7 +15,7 @@ from http.cookies import SimpleCookie
 from typing import Any, Callable, Iterable, List, Optional
 from urllib.parse import urlsplit
 
-from backend.mailbox.utilities import extract_verification_code
+from backend.mailbox.utilities import extract_verification_code, strip_html
 
 HttpGet = Callable[..., Any]
 SessionFactory = Callable[[], Any]
@@ -718,11 +718,11 @@ def mail_text(message: Any) -> str:
                 parts.append(content)
     html_value = message.get("html")
     if isinstance(html_value, str):
-        parts.append(re.sub(r"<[^>]+>", " ", html_value))
+        parts.append(strip_html(html_value))
     elif isinstance(html_value, list):
         for item in html_value:
             if isinstance(item, str):
-                parts.append(re.sub(r"<[^>]+>", " ", item))
+                parts.append(strip_html(item))
     return "\n".join(parts)
 
 

--- a/backend/mailbox/utilities.py
+++ b/backend/mailbox/utilities.py
@@ -32,21 +32,56 @@ def pick_list_payload(data: Any) -> List[dict]:
     return []
 
 
+_SCRIPT_STYLE_RE = re.compile(r"<(script|style)\b[^>]*>.*?</\1\s*>", re.IGNORECASE | re.DOTALL)
+_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_TAG_RE = re.compile(r"<[^>]+>")
+
+# 验证码形如 I6R-B2W：必须全大写，否则邮件模板里的 CSS 类名（如 sm-w-per-100）会被误判。
+_CODE_TOKEN = r"[A-Z0-9]{3}-[A-Z0-9]{3}"
+_CODE_WITH_CONTEXT_RE = re.compile(
+    r"(?:code|验证码)\s*(?:is|：|:)?\s*\b(" + _CODE_TOKEN + r")\b", re.IGNORECASE
+)
+_CODE_BARE_RE = re.compile(r"\b(" + _CODE_TOKEN + r")\b")
+_NUMERIC_CODE_RES = [
+    re.compile(r"verification\s+code[:\s]+(\d{4,8})", re.IGNORECASE),
+    re.compile(r"your\s+code[:\s]+(\d{4,8})", re.IGNORECASE),
+    re.compile(r"confirm(?:ation)?\s+code[:\s]+(\d{4,8})", re.IGNORECASE),
+]
+
+
+def strip_html(html: str) -> str:
+    """剥掉 HTML 标签，取纯文本。
+
+    必须先删除 script/style 块与注释：只删尖括号的话，<style> 里的 CSS 正文
+    会原样留在结果里，其中的类名（如 .sm-w-per-100）会被验证码正则误命中。
+    """
+    if not html:
+        return ""
+    cleaned = _SCRIPT_STYLE_RE.sub(" ", html)
+    cleaned = _COMMENT_RE.sub(" ", cleaned)
+    return _TAG_RE.sub(" ", cleaned)
+
+
+def _match_code(pattern: re.Pattern, source: str) -> Optional[str]:
+    """取第一个含字母的匹配，纯数字串（如 100-200）不是验证码。"""
+    for match in pattern.finditer(source):
+        token = match.group(1)
+        if any(ch.isalpha() for ch in token):
+            return token
+    return None
+
+
 def extract_verification_code(text: str, subject: str = "") -> Optional[str]:
-    if subject:
-        match = re.search(r"^([A-Z0-9]{3}-[A-Z0-9]{3})\s+xAI", subject, re.IGNORECASE)
-        if match:
-            return match.group(1)
-    match = re.search(r"\b([A-Z0-9]{3}-[A-Z0-9]{3})\b", text or "", re.IGNORECASE)
-    if match:
-        return match.group(1)
-    patterns = [
-        r"verification\s+code[:\s]+(\d{4,8})",
-        r"your\s+code[:\s]+(\d{4,8})",
-        r"confirm(?:ation)?\s+code[:\s]+(\d{4,8})",
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, text or "", re.IGNORECASE)
+    subject = subject or ""
+    text = text or ""
+    # 主题最干净，优先；正文里带 code 关键字的上下文次之，裸 token 最后。
+    for pattern in (_CODE_WITH_CONTEXT_RE, _CODE_BARE_RE):
+        for source in (subject, text):
+            code = _match_code(pattern, source)
+            if code:
+                return code
+    for pattern in _NUMERIC_CODE_RES:
+        match = pattern.search(text) or pattern.search(subject)
         if match:
             return match.group(1)
     return None

--- a/backend/mailbox/yyds_mail.py
+++ b/backend/mailbox/yyds_mail.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import re
 import secrets
 import string
 import time
 from typing import Any, Callable, List, Optional
 
-from backend.mailbox.utilities import extract_verification_code
+from backend.mailbox.utilities import extract_verification_code, strip_html
 
 API_BASE = "https://maliapi.215.im/v1"
 HttpGet = Callable[..., Any]
@@ -202,7 +201,7 @@ def wait_for_code(
                 parts.append(text_body)
             html_list = detail.get("html") or []
             for h in html_list:
-                parts.append(re.sub(r"<[^>]+>", " ", h))
+                parts.append(strip_html(h))
             combined = "\n".join(parts)
             subject = detail.get("subject", "")
             if log_callback:


### PR DESCRIPTION
## Summary

- Strip style blocks before extracting verification codes
- Tighten the code-matching regex
- Reduce false verification-code matches

## Testing

- Verified code extraction with HTML emails containing style blocks
- Confirmed valid verification codes are still detected