### PR TITLE
Fix possible fix(deps): curl_cffi 0.13.0 → 0.15.0 (CVE-2026-33752) in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 camoufox[geoip]>=0.5.4,<0.6
 cloakbrowser[geoip]>=0.5.7,<0.6
-curl_cffi==0.13.0
+curl_cffi==0.15.0
 fastapi>=0.110
 uvicorn[standard]>=0.27


### PR DESCRIPTION
Small change to `requirements.txt` — a scan flagged the code below and it looked genuine. It is around line 3.

The vulnerability CVE-2026-33752 in curl_cffi versions prior to 0.15.0 does not restrict redirects to internal IP ranges and leverages the library’s TLS impersonation feature. An attacker can supply a malicious URL that automatically redirects to internal services (e.g., cloud metadata endpoints), making the traffic appear as legitimate browser activity and bypassing network controls. This can lead to unauthorized access, data leakage, or exploitation of internal services, representing a high‑risk issue.

Update curl_cffi to version 0.15.0 to address CVE-2026-33752.

For reference: rule `CVE-2026-33752`. Rated high.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
