### PR TITLE
feat: 代理地址支持 {session} 占位符，每个浏览器会话分配独立粘性出口 IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Windows 启动：
 | `email_provider` | 邮箱服务商 |
 | `register_count` | 注册数量 |
 | `register_workers` | 并发数量，默认 1 |
-| `proxy` | 注册和 OAuth 请求使用的 HTTP(S) 代理；支持 `http://host:port` 和 `http://user:password@host:port`，凭据中的特殊字符需使用 URL 百分号编码。注册风控会记录浏览器识别到的出口 IP；下次若仍是该 IP，会重启浏览器换出口后再注册。风控名单在「账号中心 → 出口 IP 风控」查看，单账号出口 IP 在「账号中心 → 账号管理 → 查看」详情中 |
+| `proxy` | 注册和 OAuth 请求使用的 HTTP(S) 代理；支持 `http://host:port` 和 `http://user:password@host:port`，凭据中的特殊字符需使用 URL 百分号编码。注册风控会记录浏览器识别到的出口 IP；下次若仍是该 IP，会重启浏览器换出口后再注册。风控名单在「账号中心 → 出口 IP 风控」查看，单账号出口 IP 在「账号中心 → 账号管理 → 查看」详情中。代理地址支持 `{session}` 占位符：每次启动浏览器（含风控换出口的重启）时替换为新的随机标识，例如 `http://register.{session}:token@resin:2260`，配合 resin 等按认证用户名分配粘性会话的代理池，可实现"每个浏览器会话一个固定出口 IP、会话结束即弃"，同时保证会话期间出口 IP 不变 |
 | `browser_engine` | 浏览器后端：`camoufox`（默认）或 `cloakbrowser` |
 | `browser_headless` | 本机无头模式；Docker 中强制关闭 |
 | `browser_low_traffic_mode` | 低流量注册模式，默认开启；复用静态资源缓存并跳过非注册必需资源 |

--- a/backend/integrations/network_checks.py
+++ b/backend/integrations/network_checks.py
@@ -11,7 +11,11 @@ from typing import Callable, List, Tuple
 from urllib.parse import urlparse
 
 from backend.mailbox import cloudflare_worker as cloudflare_provider
-from backend.integrations.proxy import redact_proxy_text, resolve_proxy_url
+from backend.integrations.proxy import (
+    expand_session_placeholder,
+    redact_proxy_text,
+    resolve_proxy_url,
+)
 from backend.shared.paths import resolve_project_path
 
 CheckResult = Tuple[str, bool, str]  # name, ok, detail
@@ -367,7 +371,7 @@ def check_cpa(config: dict, http_get: Callable) -> CheckResult:
 
 def run_connectivity_checks(config: dict, http_get: Callable, http_post: Callable) -> List[CheckResult]:
     results = []
-    proxy = resolve_proxy_url(config.get("proxy", ""))
+    proxy = expand_session_placeholder(resolve_proxy_url(config.get("proxy", "")))
     results.append(check_proxy(proxy, http_get))
     results.append(check_xai_signup(proxy, http_get))
     results.append(

--- a/backend/integrations/proxy.py
+++ b/backend/integrations/proxy.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import re
+import secrets
 from urllib.parse import unquote, urlsplit, urlunsplit
 
 
@@ -128,6 +129,19 @@ def redact_proxy_text(value: object) -> str:
     return _AUTHENTICATED_PROXY_IN_TEXT.sub(
         r"\1***:***@", str(value if value is not None else "")
     )
+
+
+def expand_session_placeholder(proxy_url: str) -> str:
+    """把代理地址里的 {session} 占位符替换为新的随机标识（每次调用独立生成）。
+
+    配合 resin 等按认证用户名（Platform.Account）分配粘性会话的代理池使用：
+    每个调用方（如一次浏览器启动）拿到全新标识即获得全新出口 IP。
+    不含占位符时原样返回。
+    """
+    value = str(proxy_url or "")
+    if "{session}" not in value:
+        return value
+    return value.replace("{session}", secrets.token_hex(6))
 
 
 def resolve_proxy_url(proxy_url: str) -> str:

--- a/backend/registration/engine.py
+++ b/backend/registration/engine.py
@@ -45,7 +45,12 @@ from backend.automation import session as _bs
 from backend.registration import signup_flow as _rf
 from backend.integrations import network_checks as _conn
 from backend.registration.store import RegistrationRepository
-from backend.integrations.proxy import redact_proxy_text, redact_proxy_url, resolve_proxy_url
+from backend.integrations.proxy import (
+    expand_session_placeholder,
+    redact_proxy_text,
+    redact_proxy_url,
+    resolve_proxy_url,
+)
 from backend.shared.paths import DATA_ROOT, PROJECT_ROOT
 from backend.automation.session import (
     browser,
@@ -892,6 +897,11 @@ DUCKMAIL_API_BASE_DEFAULT = duckmail_provider.API_BASE_DEFAULT
 def get_proxies():
     proxy = resolve_proxy_url(config.get("proxy", ""))
     if proxy:
+        # 支持 {session} 占位符：每次调用替换为新的随机标识。
+        # 浏览器每次启动时调用本函数取代理，因此每个浏览器会话获得独立标识；
+        # 配合 resin 等按“账号”维度分配粘性出口的代理池（认证用户名 Platform.Account），
+        # 可实现“一次注册会话一个全新出口 IP，会话结束租约到期即弃”。
+        proxy = expand_session_placeholder(proxy)
         return {"http": proxy, "https": proxy}
     return {}
 

--- a/backend/tests/test_proxy_resolution.py
+++ b/backend/tests/test_proxy_resolution.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 from backend.integrations.proxy import (
+    expand_session_placeholder,
     parse_http_proxy_url,
     redact_proxy_text,
     redact_proxy_url,
@@ -98,6 +99,46 @@ class HttpProxyParsingTests(unittest.TestCase):
             "failed via http://user:raw/secret@proxy.example.com:8080"
         )
         self.assertNotIn("raw/secret", malformed)
+
+
+class ExpandSessionPlaceholderTests(unittest.TestCase):
+    def test_placeholder_replaced_with_fresh_token(self):
+        first = expand_session_placeholder("http://register.{session}:t@h:1")
+        second = expand_session_placeholder("http://register.{session}:t@h:1")
+        self.assertNotIn("{session}", first)
+        self.assertNotEqual(first, second)
+
+    def test_no_placeholder_unchanged(self):
+        proxy = "http://register.fixed:t@h:1"
+        self.assertEqual(expand_session_placeholder(proxy), proxy)
+        self.assertEqual(expand_session_placeholder(""), "")
+
+
+class ProxySessionPlaceholderTests(unittest.TestCase):
+    """get_proxies 的 {session} 占位符：每次调用生成新标识，无占位符时保持不变。"""
+
+    def _get(self, proxy):
+        from backend.registration import engine
+
+        with mock.patch.dict(engine.config, {"proxy": proxy}):
+            return engine.get_proxies()
+
+    def test_session_placeholder_replaced_per_call(self):
+        first = self._get("http://register.{session}:token@proxy.example.com:2260")
+        second = self._get("http://register.{session}:token@proxy.example.com:2260")
+        self.assertNotIn("{session}", first["http"])
+        self.assertNotIn("{session}", second["http"])
+        self.assertNotEqual(first["http"], second["http"])
+        self.assertTrue(
+            first["http"].startswith("http://register.") , first["http"]
+        )
+        self.assertIn(":token@proxy.example.com:2260", first["http"])
+        self.assertEqual(first["http"], first["https"])
+
+    def test_proxy_without_placeholder_unchanged(self):
+        proxy = "http://register.fixed:token@proxy.example.com:2260"
+        self.assertEqual(self._get(proxy)["http"], proxy)
+        self.assertEqual(self._get(proxy)["http"], proxy)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

使用 resin 等按认证用户名（`Platform.Account`）分配粘性会话的代理池时，当前 `proxy` 配置是全局静态字符串，导致两种都不够理想的行为：

- 不指定账号标识 → 同一次注册会话内的请求**逐个漂移出口 IP**（正常用户不会在注册中途换 IP）
- 指定固定账号标识 → 多次注册复用同一出口 IP，且内置的「出口 IP 风控回避」（发现下次仍是已风控 IP 就重启浏览器换出口）会失效，因为重启后分到的还是同一个粘性会话

## 改动

`get_proxies()` 支持 `{session}` 占位符：代理串包含 `{session}` 时，每次调用替换为新的随机标识（`secrets.token_hex(6)`）。

浏览器每次启动恰好调用一次本函数取代理，因此语义为：

- **每个浏览器会话 = 一个全新会话标识 = 代理池分配一个全新出口 IP**
- 会话期间所有请求固定同一出口 IP
- 风控换出口重启浏览器时自动获得新 IP，与现有回避机制正确联动
- 会话结束后代理池侧租约到期自动释放，无需维护

配置示例：`http://register.{session}:token@resin:2260`

不含占位符的配置行为完全不变。

## 测试

`backend/tests/test_proxy_resolution.py` 新增 `ProxySessionPlaceholderTests`：

- 占位符每次调用替换且两次结果不同、其余部分保持原样
- 无占位符配置保持不变

```
python3 -m unittest backend.tests.test_proxy_resolution  # 12 tests OK
```